### PR TITLE
ADD: custom room card component

### DIFF
--- a/src/components/RoomCard.tsx
+++ b/src/components/RoomCard.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { Room } from "@/db/schema";
+import { Button } from "./ui/button";
+import Link from "next/link";
+import { Github } from "lucide-react";
+
+type Props = {
+  room: Room;
+};
+
+const LanguageTags = ({ languages }: { languages: string[] }) => {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {languages.map((language, index) => (
+        <span
+          key={index}
+          className="bg-neutral-100 dark:bg-neutral-800 border border-black/10 darK:border-white/10 text-xs rounded-full p-2"
+        >
+          {language}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+const RoomCard = ({ room }: Props) => {
+  const languages = room.language.split(" ");
+
+  return (
+    <Card className="w-full max-w-96 hover:bg-neutral-100 dark:hover:bg-neutral-900 transition flex flex-col justify-evenly">
+      <CardHeader>
+        <CardTitle>{room.name}</CardTitle>
+        <CardDescription>{room.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col gap-2">
+          <LanguageTags languages={languages} />
+          {room.githubRepo && (
+            <Link
+              href={room.githubRepo}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 hover:underline"
+            >
+              <Github
+                height={22}
+                width={22}
+                className="text-white dark:text-black bg-black dark:bg-white rounded-full p-1"
+              />
+              GitHub Link
+            </Link>
+          )}
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button asChild className="w-full">
+          <Link href={`/room/${room.id}`}>Join Room</Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default RoomCard;


### PR DESCRIPTION
This pull request introduces a new `RoomCard` component in the `src/components/RoomCard.tsx` file. The component is designed to display information about a room, including its name, description, associated languages, and a GitHub link if available. It also includes a button to join the room.

The most important changes include:

* **New `RoomCard` component**:
  - Created a new `RoomCard` component to display room details such as name, description, languages, and a GitHub link if available.
  - Added a `LanguageTags` sub-component to handle the display of language tags in the `RoomCard`.
  - Included a `Button` component that links to the room's join page.

These changes enhance the user interface by providing a card-based layout for room information, making it more visually appealing and user-friendly.